### PR TITLE
fix description text - craft spec feat 11th lvl

### DIFF
--- a/core_book/Feats.tex
+++ b/core_book/Feats.tex
@@ -521,7 +521,7 @@ Feats can be used to specialize in a particular area, to gain new abilities, or 
         \ff[8]{Greater Specialization} The bonus from your \textit{specialization} ability increases to \plus4.
 
         \ff[11]{Item Attunement} You gain an additional \glossterm{item slot}.
-        In addition, crafting magic items takes you one hour per 1,000 gp of material components.
+        In addition, crafting magic items takes you one hour per 500 gp of material components.
 
         \ff[14]{Supreme Specialization} The bonus from your \textit{specialization} ability increases to \plus6.
 

--- a/core_book/Feats.tex
+++ b/core_book/Feats.tex
@@ -521,7 +521,7 @@ Feats can be used to specialize in a particular area, to gain new abilities, or 
         \ff[8]{Greater Specialization} The bonus from your \textit{specialization} ability increases to \plus4.
 
         \ff[11]{Item Attunement} You gain an additional \glossterm{item slot}.
-        In addition, crafting magic items takes you one hour per 100 gp of material components.
+        In addition, crafting magic items takes you one hour per 1,000 gp of material components.
 
         \ff[14]{Supreme Specialization} The bonus from your \textit{specialization} ability increases to \plus6.
 


### PR DESCRIPTION
This is mostly a test since I've never made a PR from a Fork before. Seems pretty simple and straightforward though.

**The change:**
 - previously, both 5th and 11th level specified 100 gp of mats/hr crafting time
 - now, 5th level still specifies 100, but 11th level specifies 1,000 gp mats/hr crafting time